### PR TITLE
Fix calling node/nodejs binary in `nodejs_version`

### DIFF
--- a/npm_accel/__init__.py
+++ b/npm_accel/__init__.py
@@ -7,6 +7,7 @@
 """Accelerator for npm, the Node.js package manager."""
 
 # Standard library modules.
+from distutils.spawn import find_executable
 import codecs
 import copy
 import hashlib
@@ -104,8 +105,13 @@ class NpmAccel(PropertyManager):
 
     @cached_property
     def nodejs_version(self):
-        """The output of the ``nodejs --version`` command (a string)."""
-        return self.context.capture('nodejs', '--version')
+        """The output of the ``nodejs --version`` or ```node --version`` command (a string)."""
+        if find_executable('nodejs'):
+            return self.context.capture('nodejs', '--version')
+        elif find_executable('node'):
+            return self.context.capture('node', '--version')
+        else:
+            raise NodeBinaryNotFoundError("Missing nodejs/node binary!")
 
     @cached_property
     def npm_version(self):
@@ -453,3 +459,8 @@ def auto_decode(text):
 class MissingPackageFileError(Exception):
 
     """Raised when the given directory doesn't contain a ``package.json`` file."""
+
+
+class NodeBinaryNotFoundError(Exception):
+
+    """Raised when either nodejs or node binary is not found in ``PATH``."""

--- a/npm_accel/cli.py
+++ b/npm_accel/cli.py
@@ -86,7 +86,7 @@ from humanfriendly import parse_path
 from humanfriendly.terminal import usage, warning
 
 # Modules included in our package.
-from npm_accel import MissingPackageFileError, NpmAccel
+from npm_accel import MissingPackageFileError, NodeBinaryNotFoundError, NpmAccel
 
 # Initialize a logger for this module.
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ def main():
         accelerator = NpmAccel(**program_opts)
         method = getattr(accelerator, action)
         method(directory)
-    except MissingPackageFileError as e:
+    except (MissingPackageFileError, NodeBinaryNotFoundError) as e:
         warning("Error: %s", e)
         sys.exit(1)
     except Exception:


### PR DESCRIPTION
The primary nodejs executable being called `nodejs` is a Debian-ism, and is not compatible with upstream nodejs and non-Debian distros, because upstream just calls the binary `node`.

This makes the `node_version` which calls `nodejs --version` method fail on non-Debian systems, where `nodejs` is actually called `node` instead.

Instead of just executing the `nodejs` command, we now first search for it in `PATH`, using `distutils.spawn.find_executable`, which should be available on Python 2.4+. (see also: http://stackoverflow.com/a/12611523)

When no node executable is found, a NodeBinaryNotFoundError is now raised.

If one of the node executables is found, we return the result of `node/nodejs --version` as before.

Edit: to clarify: the reasoning behind Debian not calling node `node`, is that `/usr/bin/node` is actually in use by a package that pre-exists nodejs (`ax25-node`). Since the search for `nodejs` is before the search for `node`, this should not give any problems for users that have both installed. There might be a false positive when `ax25-node` is installed, but nodejs is not, but I think we can assume here npm users have nodejs installed already anyway ;)
